### PR TITLE
BLD: Add cuda-version to all outputs to prevent hash collision

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
   sha256: {{ sha }}
 
 build:
-  number: 1
+  number: 2
   skip: true  # [osx or ppc64le or cuda_compiler_version in (None, "None")]
 
 requirements:
@@ -34,11 +34,8 @@ outputs:
 
   - name: libnvjpeg2k{{ soname }}
     build:
-      run_exports:
-        # FIXME: Pin to patch version until 1.0
-        - {{ pin_subpackage("libnvjpeg2k" ~ soname, max_pin="x.x.x") }}
-      ignore_run_exports_from:
-        - {{ compiler("cuda") }}
+      ignore_run_exports:
+        - cuda-version
     files:
       - lib/libnvjpeg2k.so.*            # [linux]
       - Library\bin\nvjpeg2k*.dll       # [win]
@@ -54,7 +51,6 @@ outputs:
         # Any CUDA within the same major version
         # https://docs.nvidia.com/cuda/nvjpeg2000/userguide.html#prerequisites
         - {{ pin_compatible("cuda-version", min_pin="x", max_pin="x") }}
-      run_constrained:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
@@ -72,6 +68,8 @@ outputs:
       run_exports:
         # FIXME: Pin to patch version until 1.0
         - {{ pin_subpackage("libnvjpeg2k" ~ soname, max_pin="x.x.x") }}
+      ignore_run_exports:
+        - cuda-version
     files:
       - lib/libnvjpeg2k.so                                  # [linux]
       # - lib/pkgconfig/nvjpeg*.pc                          # [linux]
@@ -81,8 +79,11 @@ outputs:
     requirements:
       host:
         - {{ pin_subpackage("libnvjpeg2k" ~ soname, exact=True) }}
+        - cuda-version {{ cuda_compiler_version }}
       run:
         - {{ pin_subpackage("libnvjpeg2k" ~ soname, exact=True) }}
+        - {{ pin_compatible("cuda-version", min_pin="x", max_pin="x") }}
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
         - test -L $PREFIX/lib/libnvjpeg2k.so                                    # [linux]
@@ -96,11 +97,18 @@ outputs:
   - name: libnvjpeg2k-static
     build:
       skip: true  # [not linux]
+      ignore_run_exports:
+        - cuda-version
     files:
       - lib/libnvjpeg2k_static.a
     requirements:
+      host:
+        - {{ pin_subpackage("libnvjpeg2k-dev", exact=True) }}
+        - cuda-version {{ cuda_compiler_version }}
       run:
         - {{ pin_subpackage("libnvjpeg2k-dev", exact=True) }}
+        - {{ pin_compatible("cuda-version", min_pin="x", max_pin="x") }}
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
         - test -f $PREFIX/lib/libnvjpeg2k_static.a


### PR DESCRIPTION
Also removed run exports from runtime packages. Exports are only needed for the dev package.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Closes https://github.com/conda-forge/libnvimgcodec-feedstock/issues/1